### PR TITLE
fix: edge case in gh actions

### DIFF
--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -20,9 +20,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with: # Se necesita pararse en el PR y no en el commit para un posible push
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+        with:
+          # Se necesita pararse en el PR y no en el commit para un posible push, si el trigger es una pr mergeada
+          # es posible que la rama ya haya sido eliminada
+          repository: ${{ github.event.pull_request.merged != true && github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.merged != true && github.event.pull_request.head.ref }}
 
       - name: Prettier Build (background)
         run: |

--- a/legend-saga/src/fibo.rs
+++ b/legend-saga/src/fibo.rs
@@ -55,4 +55,3 @@ mod test_fibo {
         assert_eq!(result, 12586269025);
     }
 }
-// force actions


### PR DESCRIPTION
It makes corrections in edge cases in the gh actions flow.  A branch can be deleted if the pr was already merged, so in this case, the lint step in code quality check is going to fail
