### PR TITLE
feat: event replacement for sending crypto rewards via a saga

### DIFF
--- a/legend-saga/src/commence_saga.rs
+++ b/legend-saga/src/commence_saga.rs
@@ -13,6 +13,7 @@ use crate::connection::{get_or_init_publish_channel, RabbitMQClient, RabbitMQErr
 pub enum SagaTitle {
     PurchaseResourceFlow,
     RankingsUsersReward,
+    TransferCryptoRewardToRankingWinners
 }
 
 pub trait PayloadCommenceSaga {
@@ -53,6 +54,32 @@ pub struct PurchaseResourceFlowPayload {
 impl PayloadCommenceSaga for PurchaseResourceFlowPayload {
     fn saga_title(&self) -> SagaTitle {
         SagaTitle::PurchaseResourceFlow
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CryptoRankingWinners {
+    pub user_id: String,
+    pub reward: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CompletedCryptoRanking {
+    pub wallet_address: String,
+    pub winners: Vec<CryptoRankingWinners>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferCryptoRewardToRankingWinnersPayload {
+    pub completed_crypto_rankings: Vec<CompletedCryptoRanking>,
+}
+
+impl PayloadCommenceSaga for TransferCryptoRewardToRankingWinnersPayload {
+    fn saga_title(&self) -> SagaTitle {
+        SagaTitle::TransferCryptoRewardToRankingWinners
     }
 }
 

--- a/legend-saga/src/events.rs
+++ b/legend-saga/src/events.rs
@@ -27,8 +27,6 @@ pub enum MicroserviceEvent {
     LegendMissionsCompletedMissionReward,
     #[strum(serialize = "legend_missions.ongoing_mission")]
     LegendMissionsOngoingMission,
-    #[strum(serialize = "legend_rankings.crypto_ranking_finished")]
-    LegendRankingsCryptoRankingFinished,
     #[strum(serialize = "legend_rankings.rankings_finished")]
     LegendRankingsRankingsFinished,
     #[strum(serialize = "room_creator.created_room")]
@@ -183,32 +181,6 @@ pub struct LegendMissionsOngoingMissionEventPayload {
 impl PayloadEvent for LegendMissionsOngoingMissionEventPayload {
     fn event_type(&self) -> MicroserviceEvent {
         MicroserviceEvent::LegendMissionsOngoingMission
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct CryptoRankingWinners {
-    pub user_id: String,
-    pub reward: f64,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct CompletedCryptoRanking {
-    pub wallet_address: String,
-    pub winners: Vec<CryptoRankingWinners>,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct LegendRankingsCryptoRankingFinishedPayload {
-    pub completed_crypto_rankings: Vec<CompletedCryptoRanking>,
-}
-
-impl PayloadEvent for LegendRankingsCryptoRankingFinishedPayload {
-    fn event_type(&self) -> MicroserviceEvent {
-        MicroserviceEvent::LegendRankingsCryptoRankingFinished
     }
 }
 

--- a/legend-saga/src/saga.rs
+++ b/legend-saga/src/saga.rs
@@ -32,6 +32,11 @@ pub enum StepCommand {
     // Auth commands
     CreateUser,
 
+    // Blockchain commands
+    #[strum(serialize = "crypto_reward:transfer_reward_to_winners")]
+    #[serde(rename = "crypto_reward:transfer_reward_to_winners")]
+    TransferRewardToWinners,
+
     // Coins commands
     #[strum(serialize = "resource_purchased:deduct_coins")]
     #[serde(rename = "resource_purchased:deduct_coins")]


### PR DESCRIPTION
<!-- Click en Preview -->

### `Changes`

- feat: event replacement for sending crypto rewards via a saga

### `docs`

- feat: event replacement for sending crypto rewards via a saga
- docs in the file
