### PR TITLE
feat: reward from f64 to string

### DIFF
--- a/legend-saga/src/commence_saga.rs
+++ b/legend-saga/src/commence_saga.rs
@@ -61,7 +61,7 @@ impl PayloadCommenceSaga for PurchaseResourceFlowPayload {
 #[serde(rename_all = "camelCase")]
 pub struct CryptoRankingWinners {
     pub user_id: String,
-    pub reward: f64,
+    pub reward: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
<!-- Click en Preview -->

### `Changes`

This pull request includes a change to the `legend-saga/src/commence_saga.rs` file. The change modifies the `CryptoRankingWinners` struct to change the type of the `reward` field from `f64` to `String`.

### `docs`
Changed the type of the `reward` field in the `CryptoRankingWinners` struct from `f64` to `String` to ensure proper handling of reward values.
