### PR TITLE
feat: add nft fields to CompletedRanking struct

### DIFF
--- a/legend-saga/src/events.rs
+++ b/legend-saga/src/events.rs
@@ -201,6 +201,8 @@ pub struct CompletedRanking {
     pub reward: String,
     pub reward_type: String,
     pub winners: Vec<RankingWinners>,
+    pub nft_blockchain_network: Option<String>,
+    pub nft_contract_address: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/legend-saga/src/my_delivery.rs
+++ b/legend-saga/src/my_delivery.rs
@@ -7,19 +7,19 @@ pub struct MyDelivery {
     /// acknowledging the message.
     pub delivery_tag: DeliveryTag,
 
-    /// The exchange of the message. May be an empty string
+    /// The exchange of the message. Maybe an empty string
     /// if the default exchange is used.
     pub exchange: ShortString,
 
-    /// The routing key of the message. May be an empty string
-    /// if no routing key is specified.
+    // /// The routing key of the message. Maybe an empty string
+    // /// if no routing key is specified.
     // pub routing_key: ShortString,
 
-    /// Whether this message was redelivered
+    // /// Whether this message was redelivered
     // pub redelivered: bool,
 
-    /// Contains the properties and the headers of the
-    /// message.
+    // /// Contains the properties and the headers of the
+    // /// message.
     // pub properties: BasicProperties,
 
     /// The payload of the message in binary format.


### PR DESCRIPTION
<!-- Click en Preview -->

### `Changes`

- Add `nft_blockchain_network` and `nft_contract_address` to CompletedRanking struct.
- Minor changes (syntax error fixed, improvements in comments).

### `docs`

- Docs in file.
