### PR TITLE
feat(legend-saga): use String for reward 

### DIFF
--- a/legend-saga/src/events.rs
+++ b/legend-saga/src/events.rs
@@ -247,7 +247,7 @@ pub struct CompletedRanking {
 pub struct LegendMissionsSendEmailCryptoMissionCompletedPayload {
     pub user_id: String,
     pub mission_title: String,
-    pub reward: i32,
+    pub reward: String,
     pub blockchain_network: String,
     pub crypto_asset: String,
 }


### PR DESCRIPTION
TICKET:
https://legendaryum.atlassian.net/jira/software/projects/LE/boards/1?jql=assignee%20%3D%20712020%3A0ba71cb3-687c-42cf-9f25-4b1eb799e981&selectedIssue=LE-3416

RESUMEN:

- Cambia el tipo de reward a string para el evento de misión crypto.