### PR TITLE
feat(events): add intermediate rewards support

### DIFF
--- a/legend-saga/src/events.rs
+++ b/legend-saga/src/events.rs
@@ -69,6 +69,8 @@ pub enum MicroserviceEvent {
     SocialMediaRoomsDeleteInBatch,
     #[strum(serialize = "legend_rankings.new_ranking_created")]
     LegendRankingsNewRankingCreated,
+    #[strum(serialize = "legend_rankings.intermediate_reward")]
+    LegendRankingsIntermediateReward,
 }
 
 pub trait PayloadEvent {
@@ -619,5 +621,22 @@ pub struct LegendRankingsNewRankingCreatedEventPayload {
 impl PayloadEvent for LegendRankingsNewRankingCreatedEventPayload {
     fn event_type(&self) -> MicroserviceEvent {
         MicroserviceEvent::LegendRankingsNewRankingCreated
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LegendRankingsIntermediateRewardEventPayload {
+    pub user_id: String,
+    pub ranking_id: i32,
+    pub intermediate_reward_type: String,
+    pub reward_config: serde_json::Value,
+    pub template_name: String,
+    pub template_data: serde_json::Value,
+}
+
+impl PayloadEvent for LegendRankingsIntermediateRewardEventPayload {
+    fn event_type(&self) -> MicroserviceEvent {
+        MicroserviceEvent::LegendRankingsIntermediateReward
     }
 }


### PR DESCRIPTION
## Ticket:
https://legendaryum.atlassian.net/browse/LE-3640

## Resumen
Se agregó soporte para evento legend_rankings.intermediate_reward que entrega recompensas automáticas durante participación activa en rankings, de momento se entregara solo al hito de la primera partida (first_game,) que es lo que se pidio (puede llegar a escalar en un futuro con otros hitos y tipos de reward.

## Uso
Se emite cuando usuario alcanza milestones específicos (first_game) desde Rankings hacia microservicio de email.
