### PR TITLE
Feat/siplei

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,7 +603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -901,6 +907,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,10 +1147,14 @@ name = "legend-saga"
 version = "0.0.63"
 dependencies = [
  "backoff",
+ "bytes",
  "chrono",
  "ctor",
  "futures",
  "futures-lite 2.6.1",
+ "http",
+ "http-body",
+ "http-body-util",
  "lapin",
  "once_cell",
  "rand 0.10.1",
@@ -1121,6 +1164,7 @@ dependencies = [
  "strum_macros",
  "thiserror",
  "tokio",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -1677,7 +1721,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1992,6 +2036,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2158,32 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/legend-saga/Cargo.toml
+++ b/legend-saga/Cargo.toml
@@ -14,6 +14,9 @@ categories = ["asynchronous", "network-programming"]
 default = ["events", "std"]
 events = ["serde", "strum", "strum_macros", "chrono"]
 std = ["lapin", "tokio", "futures-lite", "thiserror", "serde_json", "tracing", "backoff", "once_cell", "uuid"]
+# gRPC propagation of x-operation-id. Requires `std`: it reads the same
+# task-local operation.rs defines, which lives behind that feature.
+grpc = ["std", "tower", "http", "http-body"]
 
 [dependencies]
 # Versión 3 elimina la api de topology, se sigue en https://legendaryum.atlassian.net/browse/LE-3503
@@ -30,6 +33,9 @@ strum_macros = { version = "0.28.0", optional = true }
 once_cell = { version = "1.21.4", optional = true }
 chrono = { version = "0.4.44", default-features = false, features = ["serde"], optional = true }
 uuid = { version = "1.23", features = ["v7", "serde"], optional = true }
+tower = { version = "0.5", default-features = false, optional = true }
+http = { version = "1", optional = true }
+http-body = { version = "1", optional = true }
 
 [dev-dependencies]
 ctor = "0.12.0"
@@ -37,3 +43,6 @@ rand = "0.10.1"
 tracing-subscriber = "0.3.23"
 futures = "0.3.32"
 tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread"] }
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"
+bytes = "1"

--- a/legend-saga/src/commence_saga.rs
+++ b/legend-saga/src/commence_saga.rs
@@ -1,4 +1,5 @@
 use crate::queue_consumer_props::Queue;
+use crate::operation::operation_headers;
 use lapin::{options::BasicPublishOptions, BasicProperties};
 use serde::{Deserialize, Serialize};
 use strum_macros::{AsRefStr, EnumIter, EnumString};
@@ -83,6 +84,7 @@ impl RabbitMQClient {
                 BasicPublishOptions::default(),
                 &body,
                 BasicProperties::default()
+                    .with_headers(operation_headers())
                     .with_delivery_mode(2) // persistent
                     .with_content_type("application/json".into()),
             )

--- a/legend-saga/src/events.rs
+++ b/legend-saga/src/events.rs
@@ -104,6 +104,9 @@ pub enum MicroserviceEvent {
     BillingSubscriptionCanceled,
     #[strum(serialize = "billing.subscription_expired")]
     BillingSubscriptionExpired,
+    // Platform events - Level 1 entitlements (an operation pays SIPLEI)
+    #[strum(serialize = "platform.operation_features_changed")]
+    PlatformOperationFeaturesChanged,
     // Legend Events - Event and registration domain events
     #[strum(serialize = "legend_events.new_event_created")]
     LegendEventsNewEventCreated,
@@ -221,6 +224,22 @@ pub struct AuthOperationCreatedPayload {
 impl PayloadEvent for AuthOperationCreatedPayload {
     fn event_type(&self) -> MicroserviceEvent {
         MicroserviceEvent::AuthOperationCreated
+    }
+}
+
+/// An operation's effective feature set changed (plan assignment or feature
+/// override) — an invalidation signal, not a snapshot. A consumer refetches
+/// the effective set from legend-billing rather than trust a payload that
+/// could drift from the feature schema that lives there.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PlatformOperationFeaturesChangedPayload {
+    pub operation_id: String,
+}
+
+impl PayloadEvent for PlatformOperationFeaturesChangedPayload {
+    fn event_type(&self) -> MicroserviceEvent {
+        MicroserviceEvent::PlatformOperationFeaturesChanged
     }
 }
 

--- a/legend-saga/src/events.rs
+++ b/legend-saga/src/events.rs
@@ -31,6 +31,8 @@ pub enum MicroserviceEvent {
     AuthNewUser,
     #[strum(serialize = "auth.blocked_user")]
     AuthBlockedUser,
+    #[strum(serialize = "auth.operation_created")]
+    AuthOperationCreated,
     #[strum(serialize = "legend_missions.new_mission_created")]
     LegendMissionsNewMissionCreated,
     #[strum(serialize = "legend_missions.ongoing_mission")]
@@ -202,6 +204,23 @@ pub struct AuthBlockedUserPayload {
 impl PayloadEvent for AuthBlockedUserPayload {
     fn event_type(&self) -> MicroserviceEvent {
         MicroserviceEvent::AuthBlockedUser
+    }
+}
+
+/// identity_mode is immutable once an operation exists, so this creation-time
+/// event is the only one a consumer needs to build a local
+/// {operation_id -> identity_mode} projection (IDR-01,
+/// MODULO-IDENTITY-RESOLVER.md).
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthOperationCreatedPayload {
+    pub operation_id: String,
+    pub identity_mode: String,
+}
+
+impl PayloadEvent for AuthOperationCreatedPayload {
+    fn event_type(&self) -> MicroserviceEvent {
+        MicroserviceEvent::AuthOperationCreated
     }
 }
 

--- a/legend-saga/src/events_consume.rs
+++ b/legend-saga/src/events_consume.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use strum::IntoEnumIterator;
 use tracing::{error, info, warn};
 use crate::connection::{RabbitMQClient, RabbitMQError};
+use crate::operation::{operation_from_headers, report_missing_operation, with_operation};
 use uuid::Uuid;
 
 #[derive(Clone)]
@@ -27,11 +28,18 @@ pub struct EventHandler {
     processed_event: String,
     publisher_microservice: String,
     event_id: String,
+    operation_id: Option<String>,
 }
 impl EventHandler {
 
     pub fn publisher_microservice(&self) -> &String {
         &self.publisher_microservice
+    }
+
+    /// The SIPLEI operation the event belongs to. `None` when the publisher did
+    /// not set it, which is expected during the migration window.
+    pub fn operation_id(&self) -> &Option<String> {
+        &self.operation_id
     }
 
     pub fn event_id(&self) -> &String {
@@ -69,11 +77,15 @@ impl EventHandler {
             event_id: self.event_id.clone(),
         };
 
+        let operation_id = self.operation_id.clone();
         // Emit the audit event using the new direct exchange method
         tokio::spawn(async move {
-            if let Err(e) = RabbitMQClient::publish_audit_event(audit_payload).await {
-                error!("Failed to emit audit.processed event: {:?}", e);
-            }
+            with_operation(operation_id, async {
+                if let Err(e) = RabbitMQClient::publish_audit_event(audit_payload).await {
+                    error!("Failed to emit audit.processed event: {:?}", e);
+                }
+            })
+            .await;
         });
 
         Ok(())
@@ -104,10 +116,14 @@ impl EventHandler {
         };
 
         // Emit the audit event (don't fail if audit fails)
+        let operation_id = self.operation_id.clone();
         tokio::spawn(async move {
-            if let Err(e) = RabbitMQClient::publish_audit_event(audit_payload).await {
-                error!("Failed to emit audit.dead_letter event: {:?}", e);
-            }
+            with_operation(operation_id, async {
+                if let Err(e) = RabbitMQClient::publish_audit_event(audit_payload).await {
+                    error!("Failed to emit audit.dead_letter event: {:?}", e);
+                }
+            })
+            .await;
         });
 
         Ok(result)
@@ -142,10 +158,14 @@ impl EventHandler {
         };
 
         // Emit the audit event (don't fail if audit fails)
+        let operation_id = self.operation_id.clone();
         tokio::spawn(async move {
-            if let Err(e) = RabbitMQClient::publish_audit_event(audit_payload).await {
-                error!("Failed to emit audit.dead_letter event: {:?}", e);
-            }
+            with_operation(operation_id, async {
+                if let Err(e) = RabbitMQClient::publish_audit_event(audit_payload).await {
+                    error!("Failed to emit audit.dead_letter event: {:?}", e);
+                }
+            })
+            .await;
         });
 
         Ok(result)
@@ -224,6 +244,11 @@ impl RabbitMQClient {
         let channel = self.events_channel.lock().await;
         let delivery = MyDelivery::new(delivery).with_app_id(publisher_microservice.clone().into()).with_message_id(event_id.clone().into());
 
+        let operation_id = operation_from_headers(&delivery.headers);
+        if operation_id.is_none() {
+            report_missing_operation(self.microservice.as_ref(), event.as_ref());
+        }
+
         let response_channel =
             EventsConsumeChannel::new(channel.clone(), delivery, queue_name.to_string());
 
@@ -241,11 +266,15 @@ impl RabbitMQClient {
             event_id: event_id.clone(),
         };
 
+        let audit_operation_id = operation_id.clone();
         // Emit the audit.received event (don't fail the main flow if audit fails)
         tokio::spawn(async move {
-            if let Err(e) = RabbitMQClient::publish_audit_event(audit_payload).await {
-                error!("Failed to emit audit.received event: {:?}", e);
-            }
+            with_operation(audit_operation_id, async {
+                if let Err(e) = RabbitMQClient::publish_audit_event(audit_payload).await {
+                    error!("Failed to emit audit.received event: {:?}", e);
+                }
+            })
+            .await;
         });
 
         let event_handler = EventHandler {
@@ -255,9 +284,12 @@ impl RabbitMQClient {
             processed_event: event.as_ref().to_string(),
             publisher_microservice,
             event_id,
+            operation_id: operation_id.clone(),
         };
 
-        emitter.emit(*event, event_handler).await;
+        // Running the handler inside the scope makes the operation propagate to
+        // anything it publishes, with no code in the consuming service.
+        with_operation(operation_id, emitter.emit(*event, event_handler)).await;
 
         Ok(())
     }

--- a/legend-saga/src/grpc.rs
+++ b/legend-saga/src/grpc.rs
@@ -1,0 +1,294 @@
+//! gRPC propagation of the SIPLEI operation, mirroring `operation.rs`'s AMQP
+//! mechanism on a second transport with the same header name
+//! ([`OPERATION_HEADER`]). Lives here rather than in a dedicated gRPC crate
+//! because that constant and the task-local it reads from are already
+//! defined here — `operation.rs`'s own doc comment declared gRPC a first-class
+//! consumer before this module existed.
+//!
+//! Two `tower::Layer`s, one per side of a call:
+//!
+//! - [`AttachOperationLayer`] — client side. Wraps a tonic `Channel` so every
+//!   outgoing call carries the operation bound to the current task, with no
+//!   per-RPC boilerplate.
+//! - [`PropagateOperationLayer`] — server side. Wraps a tonic service so every
+//!   incoming call opens the task-local scope for the duration of the
+//!   handler, before the handler runs. A handler just calls
+//!   [`current_operation`](crate::operation::current_operation) — it never
+//!   touches metadata.
+//!
+//! Both operate on the raw `http::Request`/`http::Response` level tonic's
+//! generated clients and services are built on, so they wire in once at
+//! construction time and apply to every method automatically.
+
+use crate::operation::{current_operation, with_operation, OPERATION_HEADER};
+use http::{HeaderValue, Request, Response};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+/// Client-side layer: attaches `x-operation-id` to every outgoing request
+/// from whatever operation is bound to the current task. Silent no-op when
+/// none is bound — same permissive-migration behavior as the AMQP side.
+#[derive(Debug, Clone, Default)]
+pub struct AttachOperationLayer;
+
+impl<S> Layer<S> for AttachOperationLayer {
+    type Service = AttachOperationService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AttachOperationService { inner }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AttachOperationService<S> {
+    inner: S,
+}
+
+impl<S, ReqBody> Service<Request<ReqBody>> for AttachOperationService<S>
+where
+    S: Service<Request<ReqBody>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        if let Some(operation_id) = current_operation() {
+            if let Ok(value) = HeaderValue::from_str(&operation_id) {
+                req.headers_mut().insert(OPERATION_HEADER, value);
+            }
+            // An operation_id containing bytes invalid for a header value
+            // would be a bug upstream (it should be an opaque id), not
+            // something to fail the call over. Same silent-skip stance as a
+            // missing operation.
+        }
+        self.inner.call(req)
+    }
+}
+
+/// Server-side layer: reads `x-operation-id` from the incoming request and
+/// runs the wrapped service's `call` inside that scope, so
+/// [`current_operation`](crate::operation::current_operation) resolves
+/// correctly anywhere inside the handler — including if the handler itself
+/// makes further gRPC calls that need [`AttachOperationLayer`] to keep the
+/// chain going.
+#[derive(Debug, Clone, Default)]
+pub struct PropagateOperationLayer;
+
+impl<S> Layer<S> for PropagateOperationLayer {
+    type Service = PropagateOperationService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        PropagateOperationService { inner }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PropagateOperationService<S> {
+    inner: S,
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for PropagateOperationService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let operation_id = req
+            .headers()
+            .get(OPERATION_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+
+        // Clone-and-swap: the classic tower pattern for a service that needs
+        // to move `self` into an async block while `&mut self` is still the
+        // signature tower requires. The clone must be ready to poll — tonic
+        // services are, being either stateless or Arc-backed.
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        Box::pin(async move { with_operation(operation_id, inner.call(req)).await })
+    }
+}
+
+#[cfg(test)]
+mod test_grpc {
+    use super::*;
+    use crate::operation::with_operation;
+    use http_body_util::Empty;
+    use std::convert::Infallible;
+    use tower::service_fn;
+    use tower::ServiceExt;
+
+    fn empty_request() -> Request<Empty<bytes::Bytes>> {
+        Request::new(Empty::new())
+    }
+
+    #[tokio::test]
+    async fn attach_sets_the_header_from_the_current_task() {
+        let recorded = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let recorded_clone = recorded.clone();
+
+        let inner = service_fn(move |req: Request<Empty<bytes::Bytes>>| {
+            let recorded = recorded_clone.clone();
+            async move {
+                *recorded.lock().unwrap() = req
+                    .headers()
+                    .get(OPERATION_HEADER)
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_string);
+                Ok::<_, Infallible>(Response::new(Empty::<bytes::Bytes>::new()))
+            }
+        });
+
+        let mut svc = AttachOperationLayer.layer(inner);
+
+        with_operation(Some("op-123".to_string()), async {
+            svc.ready()
+                .await
+                .unwrap()
+                .call(empty_request())
+                .await
+                .unwrap();
+        })
+        .await;
+
+        assert_eq!(*recorded.lock().unwrap(), Some("op-123".to_string()));
+    }
+
+    #[tokio::test]
+    async fn attach_leaves_the_header_absent_without_a_bound_operation() {
+        let recorded = std::sync::Arc::new(std::sync::Mutex::new(Some("untouched".to_string())));
+        let recorded_clone = recorded.clone();
+
+        let inner = service_fn(move |req: Request<Empty<bytes::Bytes>>| {
+            let recorded = recorded_clone.clone();
+            async move {
+                *recorded.lock().unwrap() = req
+                    .headers()
+                    .get(OPERATION_HEADER)
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_string);
+                Ok::<_, Infallible>(Response::new(Empty::<bytes::Bytes>::new()))
+            }
+        });
+
+        let mut svc = AttachOperationLayer.layer(inner);
+        svc.ready()
+            .await
+            .unwrap()
+            .call(empty_request())
+            .await
+            .unwrap();
+
+        assert_eq!(*recorded.lock().unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn propagate_opens_the_scope_the_handler_reads() {
+        let inner = service_fn(|_req: Request<Empty<bytes::Bytes>>| async move {
+            let seen = current_operation();
+            Ok::<_, Infallible>(Response::new(Empty::<bytes::Bytes>::new()).map(|_| seen))
+        });
+
+        let mut svc = PropagateOperationLayer.layer(inner);
+
+        let mut req = empty_request();
+        req.headers_mut().insert(
+            OPERATION_HEADER,
+            HeaderValue::from_static("op-from-metadata"),
+        );
+
+        let resp = svc.ready().await.unwrap().call(req).await.unwrap();
+        assert_eq!(resp.into_body(), Some("op-from-metadata".to_string()));
+    }
+
+    #[tokio::test]
+    async fn propagate_binds_none_without_the_header() {
+        let inner = service_fn(|_req: Request<Empty<bytes::Bytes>>| async move {
+            let seen = current_operation();
+            Ok::<_, Infallible>(Response::new(Empty::<bytes::Bytes>::new()).map(|_| seen))
+        });
+
+        let mut svc = PropagateOperationLayer.layer(inner);
+        let resp = svc
+            .ready()
+            .await
+            .unwrap()
+            .call(empty_request())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.into_body(), None);
+    }
+
+    // The chain that matters end to end: a server receives an operation,
+    // and a further outgoing call made from inside that handler carries it
+    // onward without the handler doing anything special.
+    #[tokio::test]
+    async fn propagate_then_attach_forwards_the_operation_across_a_hop() {
+        let downstream_recorded = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let downstream_recorded_clone = downstream_recorded.clone();
+
+        let downstream = service_fn(move |req: Request<Empty<bytes::Bytes>>| {
+            let recorded = downstream_recorded_clone.clone();
+            async move {
+                *recorded.lock().unwrap() = req
+                    .headers()
+                    .get(OPERATION_HEADER)
+                    .and_then(|v| v.to_str().ok())
+                    .map(str::to_string);
+                Ok::<_, Infallible>(Response::new(Empty::<bytes::Bytes>::new()))
+            }
+        });
+        let downstream_client = AttachOperationLayer.layer(downstream);
+
+        let handler = tower::service_fn(move |_req: Request<Empty<bytes::Bytes>>| {
+            let mut downstream_client = downstream_client.clone();
+            async move {
+                downstream_client
+                    .ready()
+                    .await
+                    .unwrap()
+                    .call(Request::new(Empty::new()))
+                    .await
+                    .unwrap();
+                Ok::<_, Infallible>(Response::new(Empty::<bytes::Bytes>::new()))
+            }
+        });
+        let mut incoming_server = PropagateOperationLayer.layer(handler);
+
+        let mut req = empty_request();
+        req.headers_mut().insert(
+            OPERATION_HEADER,
+            HeaderValue::from_static("op-hopping-through"),
+        );
+        incoming_server
+            .ready()
+            .await
+            .unwrap()
+            .call(req)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *downstream_recorded.lock().unwrap(),
+            Some("op-hopping-through".to_string())
+        );
+    }
+}

--- a/legend-saga/src/lib.rs
+++ b/legend-saga/src/lib.rs
@@ -14,6 +14,7 @@ cfg_std! {
     mod fibo;
     mod my_delivery;
     mod nack;
+    pub mod operation;
     mod publish_event;
     mod queue_consumer_props;
     pub mod saga;

--- a/legend-saga/src/lib.rs
+++ b/legend-saga/src/lib.rs
@@ -26,5 +26,8 @@ cfg_std! {
 #[cfg(feature = "events")]
 pub mod events;
 
+#[cfg(feature = "grpc")]
+pub mod grpc;
+
 #[cfg(test)]
 mod test;

--- a/legend-saga/src/operation.rs
+++ b/legend-saga/src/operation.rs
@@ -1,0 +1,162 @@
+use lapin::types::{AMQPValue, FieldTable};
+use once_cell::sync::OnceCell;
+use std::future::Future;
+
+/// The AMQP header carrying the SIPLEI operation identifier.
+/// The same key is used for gRPC metadata so there is a single name across transports.
+pub const OPERATION_HEADER: &str = "x-operation-id";
+
+tokio::task_local! {
+    static OPERATION: Option<String>;
+}
+
+type MissingOperationHook = Box<dyn Fn(&str, &str) + Send + Sync>;
+
+static MISSING_OPERATION_HOOK: OnceCell<MissingOperationHook> = OnceCell::new();
+
+/// Registers the callback invoked when a consumed message carries no operation.
+/// A hook keeps the library free of a metrics backend; services wire it to
+/// `events_without_operation_total`. Only the first registration takes effect.
+pub fn set_missing_operation_hook<F>(hook: F) -> Result<(), &'static str>
+where
+    F: Fn(&str, &str) + Send + Sync + 'static,
+{
+    MISSING_OPERATION_HOOK
+        .set(Box::new(hook))
+        .map_err(|_| "missing operation hook already set")
+}
+
+pub(crate) fn report_missing_operation(microservice: &str, event_type: &str) {
+    if let Some(hook) = MISSING_OPERATION_HOOK.get() {
+        hook(microservice, event_type);
+    }
+}
+
+/// Runs `f` with `operation_id` bound to the current task.
+///
+/// Task-locals are not inherited by `tokio::spawn`, so anything spawned inside
+/// `f` must capture the operation and re-enter this scope.
+pub async fn with_operation<F, R>(operation_id: Option<String>, f: F) -> R
+where
+    F: Future<Output = R>,
+{
+    OPERATION.scope(operation_id, f).await
+}
+
+/// Returns the operation bound to the current task, if any.
+pub fn current_operation() -> Option<String> {
+    OPERATION.try_with(|operation| operation.clone()).ok().flatten()
+}
+
+pub(crate) fn operation_from_headers(headers: &FieldTable) -> Option<String> {
+    match headers.inner().get(OPERATION_HEADER) {
+        Some(AMQPValue::LongString(value)) => Some(value.to_string()),
+        Some(AMQPValue::ShortString(value)) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+/// Adds the operation header when the current task carries one. Messages
+/// published without an operation are left untouched, which keeps the
+/// permissive migration window working.
+pub(crate) fn apply_operation_header(headers: &mut FieldTable) {
+    if let Some(operation_id) = current_operation() {
+        headers.insert(
+            OPERATION_HEADER.into(),
+            AMQPValue::LongString(operation_id.into()),
+        );
+    }
+}
+
+pub(crate) fn operation_headers() -> FieldTable {
+    let mut headers = FieldTable::default();
+    apply_operation_header(&mut headers);
+    headers
+}
+
+#[cfg(test)]
+mod test_operation {
+    use super::*;
+
+    #[tokio::test]
+    async fn current_operation_inside_scope() {
+        let got = with_operation(Some("op-123".to_string()), async { current_operation() }).await;
+
+        assert_eq!(got, Some("op-123".to_string()));
+    }
+
+    #[tokio::test]
+    async fn current_operation_outside_scope() {
+        assert_eq!(current_operation(), None);
+    }
+
+    #[tokio::test]
+    async fn current_operation_with_none_bound() {
+        let got = with_operation(None, async { current_operation() }).await;
+
+        assert_eq!(got, None);
+    }
+
+    #[tokio::test]
+    async fn nested_scope_overrides() {
+        let got = with_operation(Some("outer".to_string()), async {
+            with_operation(Some("inner".to_string()), async { current_operation() }).await
+        })
+        .await;
+
+        assert_eq!(got, Some("inner".to_string()));
+    }
+
+    #[test]
+    fn operation_from_headers_reads_long_string() {
+        let mut headers = FieldTable::default();
+        headers.insert(
+            OPERATION_HEADER.into(),
+            AMQPValue::LongString("op-123".into()),
+        );
+
+        assert_eq!(operation_from_headers(&headers), Some("op-123".to_string()));
+    }
+
+    #[test]
+    fn operation_from_headers_missing_or_wrong_type() {
+        assert_eq!(operation_from_headers(&FieldTable::default()), None);
+
+        let mut headers = FieldTable::default();
+        headers.insert(OPERATION_HEADER.into(), AMQPValue::LongInt(42));
+        assert_eq!(operation_from_headers(&headers), None);
+    }
+
+    #[tokio::test]
+    async fn apply_operation_header_sets_the_key() {
+        let headers = with_operation(Some("op-123".to_string()), async { operation_headers() }).await;
+
+        assert_eq!(
+            operation_from_headers(&headers),
+            Some("op-123".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_operation_header_without_operation_leaves_table_untouched() {
+        let mut headers = FieldTable::default();
+        headers.insert("all-micro".into(), AMQPValue::LongString("yes".into()));
+
+        apply_operation_header(&mut headers);
+
+        assert_eq!(operation_from_headers(&headers), None);
+        assert_eq!(headers.inner().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn spawned_task_does_not_inherit_the_operation() {
+        // Guards the documented trap: tokio::spawn drops task-locals, so audit
+        // emission has to capture and re-enter the scope explicitly.
+        let got = with_operation(Some("op-123".to_string()), async {
+            tokio::spawn(async { current_operation() }).await.unwrap()
+        })
+        .await;
+
+        assert_eq!(got, None);
+    }
+}

--- a/legend-saga/src/publish_event.rs
+++ b/legend-saga/src/publish_event.rs
@@ -6,6 +6,7 @@ use lapin::{
 };
 use serde::Serialize;
 use crate::connection::{get_or_init_publish_channel, get_stored_microservice, RabbitMQClient, RabbitMQError};
+use crate::operation::{apply_operation_header, current_operation, operation_headers, with_operation};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::error;
 use uuid::Uuid;
@@ -30,6 +31,7 @@ impl RabbitMQClient {
             AMQPValue::LongString(event_type.as_ref().into()),
         );
         header_event.insert("all-micro".into(), AMQPValue::LongString("yes".into()));
+        apply_operation_header(&mut header_event);
 
         let body = serde_json::to_vec(&payload)?;
 
@@ -62,11 +64,17 @@ impl RabbitMQClient {
             event_id,
         };
 
+        // tokio::spawn drops task-locals, so the operation is captured here and
+        // re-entered inside the spawned task.
+        let operation_id = current_operation();
         // Fire-and-forget: log errors but don't fail the publish operation
         tokio::spawn(async move {
-            if let Err(e) = RabbitMQClient::publish_audit_event(audit_payload).await {
-                error!("Failed to emit audit.published event: {:?}", e);
-            }
+            with_operation(operation_id, async {
+                if let Err(e) = RabbitMQClient::publish_audit_event(audit_payload).await {
+                    error!("Failed to emit audit.published event: {:?}", e);
+                }
+            })
+            .await;
         });
 
         Ok(())
@@ -93,6 +101,7 @@ impl RabbitMQClient {
                 BasicPublishOptions::default(),
                 &body,
                 BasicProperties::default()
+                    .with_headers(operation_headers())
                     .with_content_type("application/json".into())
                     .with_delivery_mode(2), // persistent
             )

--- a/legend-saga/src/saga.rs
+++ b/legend-saga/src/saga.rs
@@ -1,6 +1,7 @@
 use crate::emitter::Emitter;
 use crate::my_delivery::MyDelivery;
 use crate::nack::Nack;
+use crate::operation::{operation_from_headers, report_missing_operation, with_operation};
 use crate::queue_consumer_props::Queue;
 use futures_lite::StreamExt;
 use lapin::options::{
@@ -80,6 +81,7 @@ pub struct CommandHandler {
     payload: HashMap<String, Value>,
     #[allow(dead_code)]
     saga_id: i32,
+    operation_id: Option<String>,
 }
 
 impl CommandHandler {
@@ -93,6 +95,12 @@ impl CommandHandler {
 
     pub fn get_payload(&self) -> &HashMap<String, Value> {
         &self.payload
+    }
+
+    /// The operation (tenant) the saga step belongs to, or `None` while a
+    /// publisher predates the header.
+    pub fn operation_id(&self) -> &Option<String> {
+        &self.operation_id
     }
 
     pub async fn ack(&self, payload_for_next_step: Value) -> Result<(), RabbitMQError> {
@@ -127,6 +135,7 @@ struct MicroserviceConsumeChannel {
     queue_name: String,
     step: SagaStep,
     nack: Nack,
+    operation_id: Option<String>,
 }
 
 impl RabbitMQClient {
@@ -179,26 +188,41 @@ impl RabbitMQClient {
         let saga_id = current_step.saga_id;
         let previous_payload = current_step.previous_payload.clone();
 
+        let operation_id = operation_from_headers(&delivery.headers);
+        if operation_id.is_none() {
+            report_missing_operation(current_step.microservice.as_ref(), command.as_ref());
+        }
+
         let response_channel = MicroserviceConsumeChannel::new(
             channel.clone(),
             delivery,
             queue_name.to_string(),
             current_step,
+            operation_id.clone(),
         );
 
         let event_handler = CommandHandler {
             payload: previous_payload,
             channel: response_channel,
             saga_id,
+            operation_id: operation_id.clone(),
         };
 
-        emitter.emit(command, event_handler).await;
+        // Running the handler inside the scope makes the operation propagate to
+        // anything it publishes, with no code in the consuming service.
+        with_operation(operation_id, emitter.emit(command, event_handler)).await;
         Ok(())
     }
 }
 
 impl MicroserviceConsumeChannel {
-    fn new(channel: Channel, delivery: MyDelivery, queue_name: String, step: SagaStep) -> Self {
+    fn new(
+        channel: Channel,
+        delivery: MyDelivery,
+        queue_name: String,
+        step: SagaStep,
+        operation_id: Option<String>,
+    ) -> Self {
         let nack = Nack::new(channel.clone(), delivery.clone(), queue_name.clone());
         Self {
             channel,
@@ -206,6 +230,7 @@ impl MicroserviceConsumeChannel {
             queue_name,
             step,
             nack,
+            operation_id,
         }
     }
     async fn ack(&self, payload_for_next_step: Value) -> Result<(), RabbitMQError> {
@@ -243,7 +268,7 @@ impl MicroserviceConsumeChannel {
         // Para que este micro pueda realizar pasos del saga y realizar commence_saga ops las queue's deben existir, no es responsabilidad
         // de los micros crear estos recursos, el micro "transactional" debe crear estos recursos -> "queue.CommenceSaga" en commenceSagaListener
         // y "queue.ReplyToSaga" en startGlobalSagaStepListener
-        RabbitMQClient::send(Queue::REPLY_TO_SAGA, &step).await?;
+        with_operation(self.operation_id.clone(), RabbitMQClient::send(Queue::REPLY_TO_SAGA, &step)).await?;
 
         self.channel
             .basic_ack(self.delivery.delivery_tag, BasicAckOptions::default())


### PR DESCRIPTION
 rust-library (legend-saga)

Título: feat(operation): propagar la operación SIPLEI por eventos, saga steps y gRPC

## Qué

Paridad completa con la librería Go.

## Cómo

Usa `tokio::task_local` en vez de pasar la operación por parámetro: el handler la
propaga a todo lo que publique, sin plumbing en el micro.

| Archivo | Qué aporta |
|---|---|
| `operation.rs` | `with_operation` / `current_operation`, `operation_headers`, hook de faltantes |
| `grpc.rs` | `AttachOperationLayer` (cliente) y `PropagateOperationLayer` (servidor) |
| `events_consume.rs` | `EventHandler::operation_id()` y el handler corriendo dentro del scope |
| `saga.rs` | `CommandHandler::operation_id()`; el step corre en scope y su `ack` responde con la operación |
| `publish_event.rs`, `commence_saga.rs` | adjuntan el header al publicar |
| `events.rs` | los dos eventos nuevos |

## Lo que estaba roto

El consumo de **eventos** ya ataba la operación, pero el de **saga steps** no — una
asimetría con la librería Go, que sí lo hacía. Un saga que cruzaba varios micros perdía
el tenant en el primer salto. Queda cerrado.

## Feature flag

Las capas gRPC van detrás de la feature `grpc`, así los micros que solo consumen eventos
no arrastran `tonic` ni `tower`.

## ⚠️ Antes de publicar

El `Cargo.toml` dice `0.0.63`, **que ya está publicada en crates.io desde el 22 de junio
con otro contenido**. Hay que bumpear a `0.0.64` o `cargo publish` va a rebotar.

## Verificación

14 tests. Clippy sin errores.
