### PR TITLE
feat(events): add features field to billing subscription payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,7 +1144,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legend-saga"
-version = "0.0.64"
+version = "0.0.63"
 dependencies = [
  "backoff",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,7 +1144,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "legend-saga"
-version = "0.0.63"
+version = "0.0.64"
 dependencies = [
  "backoff",
  "bytes",

--- a/legend-saga/src/events.rs
+++ b/legend-saga/src/events.rs
@@ -51,6 +51,12 @@ pub enum MicroserviceEvent {
     LegendMissionsSendEmailGiftCardMissionCompleted,
     #[strum(serialize = "legend_rankings.rankings_finished")]
     LegendRankingsRankingsFinished,
+    /// A distinct player's first participation in a ranking was recorded
+    /// (the billable unit — the same player playing 50 times counts once).
+    /// Invalidation signal, not a snapshot: consumers re-fetch the count
+    /// they need rather than trust a total baked into the event.
+    #[strum(serialize = "legend_rankings.billable_participant_recorded")]
+    LegendRankingsBillableParticipantRecorded,
     #[strum(serialize = "legend_showcase.product_virtual_deleted")]
     LegendShowcaseProductVirtualDeleted,
     #[strum(serialize = "legend_showcase.update_allowed_mission_subscription_ids")]
@@ -437,6 +443,21 @@ pub struct LegendRankingsRankingsFinishedEventPayload {
 impl PayloadEvent for LegendRankingsRankingsFinishedEventPayload {
     fn event_type(&self) -> MicroserviceEvent {
         MicroserviceEvent::LegendRankingsRankingsFinished
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct LegendRankingsBillableParticipantRecordedEventPayload {
+    pub operation_id: String,
+    pub source_type: String,
+    pub source_id: String,
+    pub occurred_at: String,
+}
+
+impl PayloadEvent for LegendRankingsBillableParticipantRecordedEventPayload {
+    fn event_type(&self) -> MicroserviceEvent {
+        MicroserviceEvent::LegendRankingsBillableParticipantRecorded
     }
 }
 

--- a/legend-saga/src/events.rs
+++ b/legend-saga/src/events.rs
@@ -452,6 +452,11 @@ pub struct LegendRankingsBillableParticipantRecordedEventPayload {
     pub operation_id: String,
     pub source_type: String,
     pub source_id: String,
+    // Needed so consumers can dedupe on (operation_id, source_type,
+    // source_id, user_ref) — the same composite key billable_participants
+    // uses — and stay correct under RabbitMQ redelivery instead of
+    // double-counting.
+    pub user_ref: String,
     pub occurred_at: String,
 }
 

--- a/legend-saga/src/events.rs
+++ b/legend-saga/src/events.rs
@@ -850,6 +850,8 @@ pub struct BillingSubscriptionCreatedPayload {
     pub period_start: String,
     pub period_end: String,
     pub occurred_at: String,
+    #[serde(default)]
+    pub features: Vec<String>,
 }
 
 impl PayloadEvent for BillingSubscriptionCreatedPayload {
@@ -871,6 +873,8 @@ pub struct BillingSubscriptionUpdatedPayload {
     pub period_start: String,
     pub period_end: String,
     pub occurred_at: String,
+    #[serde(default)]
+    pub features: Vec<String>,
 }
 
 impl PayloadEvent for BillingSubscriptionUpdatedPayload {
@@ -890,6 +894,8 @@ pub struct BillingSubscriptionRenewedPayload {
     pub period_start: String,
     pub period_end: String,
     pub occurred_at: String,
+    #[serde(default)]
+    pub features: Vec<String>,
 }
 
 impl PayloadEvent for BillingSubscriptionRenewedPayload {


### PR DESCRIPTION
Resumen: Mismo cambio que saga, mirror Rust — features: Vec<String> con #[serde(default)] en los 3 payloads equivalentes (legend-saga/src/events.rs), plan_slug intacto. Mantiene paridad con saga, que es la fuente de verdad.